### PR TITLE
Fix deprication of node --debug-brk

### DIFF
--- a/src/TestRunner.ts
+++ b/src/TestRunner.ts
@@ -51,7 +51,7 @@ function runTestsCore(
   };
 
   if (debug) {
-    spawnTestProcessOptions.execArgv = ['--debug-brk=' + config.debugPort];
+    spawnTestProcessOptions.execArgv = ['--inspect-brk=' + config.debugPort];
   }
 
   const childProcess = spawnTestProcess(


### PR DESCRIPTION
Fix DeprecationWarning [DEP0062]: `node --debug-brk` is deprecated